### PR TITLE
URL Cleanup

### DIFF
--- a/booking-mvc/pom.xml
+++ b/booking-mvc/pom.xml
@@ -24,7 +24,7 @@
 		<repository>
 			<id>spring-repository</id>
 			<name>SpringSource Repository</name>
-			<url>http://repo.springsource.org/milestone</url>
+			<url>https://repo.springsource.org/milestone</url>
 		</repository>
 	</repositories>
 

--- a/sta-mapreduce/pom.xml
+++ b/sta-mapreduce/pom.xml
@@ -6,7 +6,7 @@
 	<packaging>jar</packaging>
 	<version>1.0-SNAPSHOT</version>
 	<name>sta-mapreduce</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://repo.springsource.org/milestone migrated to:  
  https://repo.springsource.org/milestone ([https](https://repo.springsource.org/milestone) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance